### PR TITLE
Added types to exports to support TypeScript with node12 module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "browser": "./index.browser.js",
   "types": "./index.d.ts",
   "exports": {
+    "types": "./index.d.ts",
     "node": "./index.node.js",
     "default": "./index.browser.js"
   },


### PR DESCRIPTION
When using `"moduleResolution": "node12"` (currently requires nightly TS), if `exports` is specified, then TypeScript will ignore the top-level `main`, `types`, etc. Because of this, it cannot find the type definitions. Adding the types to `exports` fixes this.